### PR TITLE
Get run_id correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
           var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{github.event.workflow_run.id }},
+              run_id: context.payload.workflow_run.id,
           });
           var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "${{inputs.artifact}}";


### PR DESCRIPTION
Hopefully fixes #1. I checked https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows for the correct usage.

Currently testing in my (private) repo.